### PR TITLE
Add default mainnet chain id to EnsName component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo-eth/core-wagmi",
-  "version": "0.0.0-beta.5",
+  "version": "0.0.0-beta.6",
   "license": "MIT",
   "author": "Kames Geraghty",
   "source": "src/index.tsx",

--- a/src/components/ens-name.tsx
+++ b/src/components/ens-name.tsx
@@ -7,16 +7,19 @@ interface EnsNameProps {
   className?: string;
   address: `0x${string}`;
   truncate: boolean;
+  chainId?: number;
 }
 
 export const EnsName = ({
   className,
   address,
   truncate = false,
+  chainId = 1,
 }: EnsNameProps) => {
   const classes = classNames(className, 'EnsName');
   const { data, isSuccess } = useEnsName({
     address: address,
+    chainId: chainId,
   });
   if (!isSuccess) return null;
   if (!data) {


### PR DESCRIPTION
this will allow functional ENS name fetching from L2s and sidechains