### PR TITLE
Fix: trimFormattedBalance helper function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo-eth/core-wagmi",
-  "version": "0.0.0-beta.7",
+  "version": "0.0.0-beta.8",
   "license": "MIT",
   "author": "Kames Geraghty",
   "source": "src/index.tsx",

--- a/src/utils/trimFormattedBalance.ts
+++ b/src/utils/trimFormattedBalance.ts
@@ -6,6 +6,8 @@ export function trimFormattedBalance(
     return '0';
   }
   const [integer, decimal] = balance.split('.');
+  if (!decimal) return integer;
+
   const trimmedDecimal = decimal.slice(0, decimals);
   return `${integer}.${trimmedDecimal}`;
 }


### PR DESCRIPTION
This pull request addresses an issue with the `trimFormattedBalance` function where it would break if the balance is an integer and `decimal` is undefined. The issue occurred when calling `.slice` on undefined, causing an error.

**Changes:**
- Added a conditional check in the `trimFormattedBalance` function to handle cases when the balance is an integer and `decimal` is undefined.
  - The updated function now includes the line `if (!decimal) return integer;` to prevent errors from occurring when calling `.slice` on undefined.
- Bumped the package version from 0.0.0-beta.7 to 0.0.0-beta.8.